### PR TITLE
Fix URL for a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "angular-hotkeys-light": "^1.1.1",
     "angular-i18n": "^1.5.9",
     "angular-ladda-lw": "^0.4.3",
-    "angular-legacy-sortablejs-maintained": "https://github.com/OzzieOrca/angular-legacy-sortablejs#fix-sortablejs-import",
+    "angular-legacy-sortablejs-maintained": "OzzieOrca/angular-legacy-sortablejs#fix-sortablejs-import",
     "angular-md5": "^0.1.10",
     "angular-messages": "^1.8.3",
     "angular-resizable": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,9 +1882,9 @@ angular-ladda-lw@^0.4.3:
   resolved "https://registry.yarnpkg.com/angular-ladda-lw/-/angular-ladda-lw-0.4.3.tgz#64ffe5b4c8c55998481c53eee7b718e080bdbfbf"
   integrity sha1-ZP/ltMjFWZhIHFPu57cY4IC9v78=
 
-"angular-legacy-sortablejs-maintained@https://github.com/OzzieOrca/angular-legacy-sortablejs#fix-sortablejs-import":
+angular-legacy-sortablejs-maintained@OzzieOrca/angular-legacy-sortablejs#fix-sortablejs-import:
   version "0.6.2"
-  resolved "https://github.com/OzzieOrca/angular-legacy-sortablejs#13f0a45b894672f4fdfa0f5904bb21e3113b6a34"
+  resolved "https://codeload.github.com/OzzieOrca/angular-legacy-sortablejs/tar.gz/13f0a45b894672f4fdfa0f5904bb21e3113b6a34"
 
 angular-md5@^0.1.10:
   version "0.1.10"


### PR DESCRIPTION
The URL for angular-legacy-sortablejs-maintained is incorrect. According
to the manual for package.json[^1], the URL would have to start with
`git+https`. Otherwise, it could be interpreted as a URL that points to
a tarball. Yarn and NPM do not have any issue with this but yarn2nix[^2]
does fail to build a package because of this. And this might affect
other tools as well.

Since the URL in question points to GitHub, this commit fixes the
problem by using the abbreviated form for GitHub URLs.

[^1]: <https://docs.npmjs.com/cli/v8/configuring-npm/package-json#git-urls-as-dependencies>
[^2]: <https://nixos.org/manual/nixpkgs/stable/#javascript-tool-specific>