### PR TITLE
Use process port if available

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -89,6 +89,8 @@ app.all("/*", (req, res) => {
 });
 //For example in Express you may want to use: res.send(noncifiedHTML);
 
+const port = process.env.PORT || 8080;
+
 app.listen(process.env.PORT || 8080, () => {
-  console.log("Financier frontend listening on port 8080!");
+  console.log(`Financier frontend listening on port ${port}!`);
 });

--- a/api/index.js
+++ b/api/index.js
@@ -89,6 +89,6 @@ app.all("/*", (req, res) => {
 });
 //For example in Express you may want to use: res.send(noncifiedHTML);
 
-app.listen(8080, () => {
+app.listen(process.env.PORT || 8080, () => {
   console.log("Financier frontend listening on port 8080!");
 });

--- a/api/index.js
+++ b/api/index.js
@@ -91,6 +91,6 @@ app.all("/*", (req, res) => {
 
 const port = process.env.PORT || 8080;
 
-app.listen(process.env.PORT || 8080, () => {
+app.listen(port, () => {
   console.log(`Financier frontend listening on port ${port}!`);
 });


### PR DESCRIPTION
In cloud deployments, the process can have a port already assigned to it. Use the process port if available or 8080.