### PR TITLE
fix: mobile layout shifted left on iOS (Sass 1.101 cascade regression)

### DIFF
--- a/src/styles/appView.scss
+++ b/src/styles/appView.scss
@@ -17,19 +17,6 @@
 }
 
 .app-view__sidebar {
-  @media (max-width: 600px) {
-    min-width: 250px; // ignore configured sidebar width
-    max-width: 250px; // ignore configured sidebar width
-
-    transform: translateX(-250px);
-
-    transition: transform 250ms ease;
-
-    .app-view--sidebar-open & {
-      transform: translateX(0);
-    }
-  }
-
   width: 15em;
   position: relative;
 
@@ -44,6 +31,19 @@
 
   a {
     text-decoration: none;
+  }
+
+  @media (max-width: 600px) {
+    min-width: 250px; // ignore configured sidebar width
+    max-width: 250px; // ignore configured sidebar width
+
+    transform: translateX(-250px);
+
+    transition: transform 250ms ease;
+
+    .app-view--sidebar-open & {
+      transform: translateX(0);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
Since **1.10.0**, the app renders shifted ~50px to the left on narrow/mobile viewports — category labels are clipped and the category list won't scroll. Reported by users on **all iOS browsers** (Safari/Chrome/Firefox all use WebKit); desktop is fine.

## Root cause
The **Sass 1.80 → 1.101** upgrade in 1.10.0, **not** the CSS minifier (verified — the bug reproduces in the unminified build too).

Sass ≥1.101 changed `mixed-decls` ordering: declarations that follow a nested `@media` are now emitted **after** the bubbled media block. In `.app-view__sidebar`, the `@media (max-width: 600px) { min-width: 250px }` was nested *before* the base `min-width: 200px`, so the base now wins the cascade → the mobile sidebar became **200px instead of 250px**.

The mobile layout slides the body `translateX(-250px)` to cover the sidebar, so `200 − 250 = −50px` → the whole app shifts 50px left. Desktop has no media query, so it was unaffected (matches "fine on Windows tablet, broken on every iPhone").

## Fix
Move the `@media` block in `.app-view__sidebar` to *after* the base `min/max-width` declarations so it wins the cascade again. One file, forward-compatible with the new Sass semantics.

## Verification (Chromium @ iPhone viewport — cascade/viewport bug, not a WebKit-engine quirk, so reproduces & fixes identically)
- Before: sidebar 200px, `.budget` at `left: -50`, labels clipped
- After: sidebar **250px**, `.budget` at `left: 0`, all labels visible, scroll restored
- Desktop layout unchanged; `lint` / 301 tests / `build` all green
- Scanned all other `@media`-first rules — only the sidebar had a real conflict (the `fp()` mixin shares the pattern but is unused).

## Follow-up
Hotfix for the 1.10.0 regression → cut **1.10.1** after merge. Consider a CI smoke test at a mobile viewport; this is the second runtime-only break that passed CI.