### PR TITLE
fix: restore touch scrolling over category/account lists on iOS

### DIFF
--- a/src/scripts/controllers/budgetCtrl.js
+++ b/src/scripts/controllers/budgetCtrl.js
@@ -43,6 +43,7 @@ angular
       updateCategories(); // run to start
 
       $scope.categorySortable = {
+        supportPointer: false,
         animation: 200,
         group: "categories",
         ghostClass: "budget__month-row--ghost",
@@ -60,6 +61,7 @@ angular
       };
 
       $scope.masterCategorySortable = {
+        supportPointer: false,
         animation: 200,
         ghostClass: "budget__month-row--ghost",
         onSort: (e) => {

--- a/src/scripts/controllers/dbCtrl.js
+++ b/src/scripts/controllers/dbCtrl.js
@@ -282,6 +282,7 @@ angular
       this.currencyDigits = currencies[budgetRecord.currency].decimal_digits;
 
       this.accountSortable = {
+        supportPointer: false,
         animation: 200,
         ghostClass: "app-view__account--ghost",
         onSort: (e) => {


### PR DESCRIPTION
## Problem
After 1.10.x, dragging up to scroll the budget category list on **iOS** grabs and reorders the category under your thumb instead of scrolling. (Reported by a user; desktop is unaffected.)

## Root cause
The dependency upgrade bumped **sortablejs 1.15.3 → 1.15.7**, which changed the `supportPointer` default:

```
1.15.3:  ... && 'PointerEvent' in window && !Safari
1.15.7:  ... && 'PointerEvent' in window && (!Safari || IOS)
```

On iOS this flips from `false` → `true`, so sortablejs now uses **Pointer Events**. It captures the gesture on `pointerdown` before the app's existing `touch-start="…disabled = true"` hook can cancel the drag, so the touch reorders instead of scrolling. Nothing in app code changed — pure sortablejs behavior change.

## Fix
Force `supportPointer: false` on all three sortables (`categorySortable`, `masterCategorySortable`, `accountSortable`), restoring the 1.15.3 event model.

| Platform | Effect of `supportPointer: false` |
|---|---|
| Desktop Chrome/FF/Edge | pointer → **mouse events** (sortablejs's original drag path; reorder unchanged) |
| Desktop Safari | mouse events (already, no change) |
| iOS | pointer → **touch events** ✅ scroll restored, `touch-start` disable works again |
| Android | pointer → touch events (consistent with iOS mobile UX) |

The only platform that regressed between versions was iOS; desktop drag continues via mouse events.

## Verification
- `lint` / 301 tests / `build` all green
- Confirmed only three sortables exist in the codebase (all covered)
- Headless desktop drag sim is unreliable for sortablejs, but `supportPointer: false` = the default mouse-event path on desktop, so drag-to-reorder is unaffected

## Follow-up
Ship as **1.10.2** after merge.